### PR TITLE
FIX: find_last() now fully functional and all tests working

### DIFF
--- a/metadataservice/server/engine.py
+++ b/metadataservice/server/engine.py
@@ -82,7 +82,6 @@ class RunStartHandler(DefaultHandler):
             raise tornado.web.HTTPError(500, reason='No results found for query')
         else:
             utils._return2client(self, docs)
-            self.finish()
 
     @tornado.web.asynchronous
     @gen.coroutine
@@ -139,7 +138,6 @@ class EventDescriptorHandler(DefaultHandler):
                                         reason='No results found for query')
         else:
             utils._return2client(self, docs)
-            self.finish()
 
     @tornado.web.asynchronous
     @gen.coroutine
@@ -193,7 +191,6 @@ class RunStopHandler(DefaultHandler):
                                         'No results for given query' + str(query))
         else:
             utils._return2client(self, docs)
-            self.finish()
 
     @tornado.web.asynchronous
     @gen.coroutine

--- a/metadataservice/server/engine.py
+++ b/metadataservice/server/engine.py
@@ -75,9 +75,14 @@ class RunStartHandler(DefaultHandler):
         database = self.settings['db']
         query = utils._unpack_params(self)
         _id = query.pop('_id', None)
+        find_last = query.pop('find_last', None)
         if _id:
             raise tornado.web.HTTPError(500, 'No ObjectId search supported')
-        docs = database.run_start.find(query)
+        if find_last:
+            docs = database.run_start.find().sort('time', direction=pymongo.DESCENDING)
+        else:
+            docs = database.run_start.find(query)
+
         if not docs:
             raise tornado.web.HTTPError(500, reason='No results found for query')
         else:

--- a/metadataservice/server/utils.py
+++ b/metadataservice/server/utils.py
@@ -5,6 +5,7 @@ from pkg_resources import resource_filename as rs_fn
 import ujson
 import pymongo.cursor
 
+
 SCHEMA_PATH = 'schema'
 SCHEMA_NAMES = {'run_start': 'run_start.json',
                 'run_stop': 'run_stop.json',


### PR DESCRIPTION
```
/Users/arkilic/anaconda/envs/py34/bin/python3 /Users/arkilic/git/pycharm/metadataclient/run_tests.py
.................................................................................S.............
Name                                              Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------------
metadataclient.py                                     0      0   100%   
metadataclient/api.py                                 3      0   100%   
metadataclient/commands.py                          314     32    90%   36-39, 108, 114, 120, 137-140, 271-275, 334, 408-418, 467, 906, 911, 923-924, 932
metadataclient/conf.py                               24      2    92%   42, 59
metadataclient/sample_data.py                         0      0   100%   
metadataclient/sample_data/common.py                 40      0   100%   
metadataclient/sample_data/multisource_event.py      46      4    91%   70-81
metadataclient/sample_data/temperature_ramp.py       44      4    91%   69-80
metadataclient/utils.py                             106      2    98%   72-73
-------------------------------------------------------------------------------
TOTAL                                               577     44    92%   
----------------------------------------------------------------------
Ran 95 tests in 79.685s

OK (SKIP=1)

Process finished with exit code 0
```

Yes, my 3 year old laptop is really this slow (no wired tiger)